### PR TITLE
SUP-5538: Показ брендов на детальной странице брендов

### DIFF
--- a/local/templates/.default/components/bitrix/news/brands/detail.php
+++ b/local/templates/.default/components/bitrix/news/brands/detail.php
@@ -199,7 +199,7 @@ $this->setFrameMode(true);
 		"ELEMENT_SORT_ORDER" => "desc",
 		"ELEMENT_SORT_ORDER2" => "desc",
 		"FILTER_NAME" => "arrFilter",
-		"HIDE_NOT_AVAILABLE" => "Y",
+		"HIDE_NOT_AVAILABLE" => "N",
 		"IBLOCK_ID" => "5",
 		"IBLOCK_TYPE" => "1c_catalog",
 		"INCLUDE_SUBSECTIONS" => "Y",


### PR DESCRIPTION
Трабл был в том, что настройки для показа товаров в каталоге и на странице брендов отличались. Страница брендов отсекала товары не в наличии